### PR TITLE
Stabilize V0.2.1 alignment + config/infer: optional rough guidance, recursive path resolution

### DIFF
--- a/configs/inference/CHN6-CUG/no_rough.yaml
+++ b/configs/inference/CHN6-CUG/no_rough.yaml
@@ -14,6 +14,7 @@ strength: 1.0
 prompt: ""
 negative_prompt: null
 use_dataset_text: true
+use_rough_guidance: false
 seed: 42
 max_samples: null
 skip_existing: true

--- a/configs/inference/Potsdam/no_rough.yaml
+++ b/configs/inference/Potsdam/no_rough.yaml
@@ -14,6 +14,7 @@ strength: 1.0
 prompt: ""
 negative_prompt: null
 use_dataset_text: true
+use_rough_guidance: false
 seed: 42
 max_samples: null
 skip_existing: true

--- a/evaluation/boundary.py
+++ b/evaluation/boundary.py
@@ -83,4 +83,3 @@ def compute_wfm_for_edge_size(
     finally:
         if cleanup:
             shutil.rmtree(pred_edge_dir, ignore_errors=True)
-            shutil.rmtree(label_edge_dir, ignore_errors=True)

--- a/src/models/SuperModel.py
+++ b/src/models/SuperModel.py
@@ -1,5 +1,6 @@
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 import torch.utils.checkpoint
 from typing import List, Optional, Tuple, Union
 
@@ -59,6 +60,7 @@ class InteractNet(ModelMixin, ConfigMixin):
 
     _supports_gradient_checkpointing = True
 
+    @register_to_config
     def __init__(
         self,
         conditioning_channels: int = 3,
@@ -237,7 +239,6 @@ class SIDModel(ModelMixin, ConfigMixin):
         self.spatial_out_tokens = spatial_out_tokens
 
         self.projectors = None
-        self.spatial_expander = None
         if z_dims:
             if hasattr(unet_gen, "config") and hasattr(
                 unet_gen.config, "block_out_channels"
@@ -247,11 +248,6 @@ class SIDModel(ModelMixin, ConfigMixin):
                 inner_dim = unet_gen.conv_out.in_channels
             self.projectors = nn.ModuleList(
                 [build_mlp(inner_dim, projector_dim, z_dim) for z_dim in z_dims]
-            )
-            self.spatial_expander = nn.Sequential(
-                nn.Linear(self.spatial_in_tokens, 256),
-                nn.GELU(),
-                nn.Linear(256, self.spatial_out_tokens),
             )
             self._initialize_projectors()
 
@@ -268,21 +264,29 @@ class SIDModel(ModelMixin, ConfigMixin):
         for projector in self.projectors:
             projector.apply(_basic_init)
 
-    def _build_representators(self, down_block_res_samples_q, down_block_res_samples):
+    def _build_representators(
+        self,
+        down_block_res_samples_q,
+        down_block_res_samples,
+        target_token_grid: Optional[Tuple[int, int]] = None,
+    ):
         if self.projectors is None:
             return None
         x = down_block_res_samples[-1]
         bsz, channels, height, width = x.shape
-        tokens = height * width
         x = x.flatten(2).permute(0, 2, 1)
         representators_tilde = []
         for projector in self.projectors:
-            z = projector(x.reshape(-1, channels)).view(bsz, tokens, -1)
-            if self.spatial_expander is not None and tokens == self.spatial_in_tokens:
-                z_expanded = self.spatial_expander(z.permute(0, 2, 1)).permute(0, 2, 1)
-            else:
-                z_expanded = z
-            representators_tilde.append(z_expanded)
+            z = projector(x.reshape(-1, channels)).view(bsz, height, width, -1)
+            z = z.permute(0, 3, 1, 2)
+            if target_token_grid is not None and tuple(target_token_grid) != (height, width):
+                z = F.interpolate(
+                    z,
+                    size=target_token_grid,
+                    mode="bilinear",
+                    align_corners=False,
+                )
+            representators_tilde.append(z.flatten(2).permute(0, 2, 1))
         return representators_tilde
 
     def connect_process(
@@ -332,6 +336,7 @@ class SIDModel(ModelMixin, ConfigMixin):
         cond_latents_2,
         timesteps,
         encoder_hidden_states,
+        target_token_grid: Optional[Tuple[int, int]] = None,
     ):
         down_block_res_samples, mid_block_sample, _ = self.connect_process(
             noise_latents,
@@ -340,7 +345,11 @@ class SIDModel(ModelMixin, ConfigMixin):
             timesteps,
             encoder_hidden_states,
         )
-        representators_tilde = self._build_representators(None, down_block_res_samples)
+        representators_tilde = self._build_representators(
+            None,
+            down_block_res_samples,
+            target_token_grid=target_token_grid,
+        )
 
         unet_output = self.unet_gen(
             noise_latents,
@@ -363,14 +372,19 @@ class SIDModel(ModelMixin, ConfigMixin):
         cond_latents_2=None,
         timesteps=None,
         encoder_hidden_states=None,
+        target_token_grid: Optional[Tuple[int, int]] = None,
+        return_representations: bool = False,
     ):
-        seg_model_pred, _ = self.get_gen_pred(
+        seg_model_pred, representators_tilde = self.get_gen_pred(
             noise_latents,
             cond_latents_1,
             cond_latents_2,
             timesteps,
             encoder_hidden_states,
+            target_token_grid=target_token_grid,
         )
+        if return_representations:
+            return seg_model_pred, representators_tilde
         return seg_model_pred
 
     @torch.no_grad()

--- a/src/models/clip.py
+++ b/src/models/clip.py
@@ -7,6 +7,14 @@ import torch.nn.functional as F
 from torch import nn
 
 
+def _to_2tuple(value):
+    if isinstance(value, (tuple, list)):
+        if len(value) != 2:
+            raise ValueError(f"Expected a 2-value tuple/list, got: {value!r}")
+        return (int(value[0]), int(value[1]))
+    return (int(value), int(value))
+
+
 class MixFFN(nn.Module):
     """An implementation of MixFFN of Segformer."""
 
@@ -675,19 +683,21 @@ class CrossAttentionLayer(nn.Module):
         eps: float = 1e-6,
     ):
         super().__init__()
+        patch_h, patch_w = _to_2tuple(patch_size)
+        self.patch_size = (patch_h, patch_w)
 
         self.conv1_q = nn.Conv2d(
             in_channels=in_channels,
             out_channels=width,
-            kernel_size=patch_size,
-            stride=patch_size,
+            kernel_size=self.patch_size,
+            stride=self.patch_size,
             bias=False,
         )
         self.conv1_k = nn.Conv2d(
             in_channels=cross_dim,
             out_channels=width,
-            kernel_size=patch_size,
-            stride=patch_size,
+            kernel_size=self.patch_size,
+            stride=self.patch_size,
             bias=False,
         )
 
@@ -697,12 +707,16 @@ class CrossAttentionLayer(nn.Module):
         self.transformer = Transformer(width, layers, heads)
 
         self.ln_post = LayerNorm(width)
-        self.input_resolution = input_resolution
+        self.input_resolution = _to_2tuple(input_resolution) if input_resolution is not None else self.patch_size
+        self.base_grid_size = (
+            max(1, self.input_resolution[0] // self.patch_size[0]),
+            max(1, self.input_resolution[1] // self.patch_size[1]),
+        )
         
         scale = width**-0.5
         self.positional_embedding = nn.Parameter(
-                    scale * torch.randn((self.input_resolution // patch_size) ** 2, width)
-                )
+            scale * torch.randn(self.base_grid_size[0] * self.base_grid_size[1], width)
+        )
         self.proj = nn.Conv2d(
             in_channels=width,
             out_channels=output_dim,
@@ -711,22 +725,37 @@ class CrossAttentionLayer(nn.Module):
             bias=False,
         )
 
+    def _get_positional_embedding(self, grid_h: int, grid_w: int, dtype, device):
+        pos = self.positional_embedding
+        if (grid_h, grid_w) != self.base_grid_size:
+            pos = pos.reshape(
+                self.base_grid_size[0], self.base_grid_size[1], -1
+            ).permute(2, 0, 1).unsqueeze(0)
+            pos = F.interpolate(
+                pos.float(),
+                size=(grid_h, grid_w),
+                mode="bicubic",
+                align_corners=False,
+            )
+            pos = pos.squeeze(0).permute(1, 2, 0).reshape(grid_h * grid_w, -1)
+        return pos.to(device=device, dtype=dtype)
+
     def x_pre(self, x: torch.Tensor, conv1: nn.Module, ln_pre: nn.Module):
-        
         x = conv1(x)  # shape = [*, width, grid, grid]
+        grid_h, grid_w = x.shape[-2:]
         x = x.reshape(x.shape[0], x.shape[1], -1)  # shape = [*, width, grid ** 2]
         x = x.permute(0, 2, 1)  # shape = [*, grid ** 2, width]
-        x = x + self.positional_embedding.to(x.dtype)
+        x = x + self._get_positional_embedding(grid_h, grid_w, x.dtype, x.device)
         x = x.permute(1, 0, 2)  # NLD -> LND
 
         x = ln_pre(x)
-        return x
+        return x, grid_h, grid_w
 
     def forward(self, q: torch.Tensor,k: torch.Tensor):
-        N, C, H, W = q.shape
+        N = q.shape[0]
         res=q
-        q = self.x_pre(q, ln_pre=self.ln_pre_q, conv1=self.conv1_q)
-        k = self.x_pre(k, ln_pre=self.ln_pre_k, conv1=self.conv1_k)
+        q, grid_h, grid_w = self.x_pre(q, ln_pre=self.ln_pre_q, conv1=self.conv1_q)
+        k, _, _ = self.x_pre(k, ln_pre=self.ln_pre_k, conv1=self.conv1_k)
         
         x = self.transformer(q,k,k)
 
@@ -734,7 +763,7 @@ class CrossAttentionLayer(nn.Module):
 
         x = self.ln_post(x)
 
-        x = x.permute(0, 2, 1).view(N, x.shape[2], H, W)
+        x = x.permute(0, 2, 1).view(N, x.shape[2], grid_h, grid_w)
 
         out = self.proj(x)
         

--- a/src/models/pipeline_sidmodel_img2img.py
+++ b/src/models/pipeline_sidmodel_img2img.py
@@ -736,6 +736,7 @@ class StableDiffusionSIDModelImg2ImgPipeline(
         prompt: Union[str, List[str]] = None,
         image: PipelineImageInput = None,
         rough_label: PipelineImageInput = None,
+        use_rough_guidance: bool = True,
         interact_direction: str = "seg",
         height: Optional[int] = None,
         width: Optional[int] = None,
@@ -932,17 +933,6 @@ class StableDiffusionSIDModelImg2ImgPipeline(
                 f"Image size {(height, width)} must be divisible by the VAE scale factor {self.vae_scale_factor}."
             )
         
-        rough_label = rough_label.to(device=device)
-        if tuple(rough_label.shape[-2:]) != (height, width):
-            raise ValueError(
-                f"Rough label tensor shape {tuple(rough_label.shape[-2:])} does not match image size {(height, width)}."
-            )
-        rough_label_embed = self.label_embed_net.encode(rough_label)
-
-        rough_lbl_latents = self.vae.encode(
-            rough_label_embed
-                ).latent_dist.sample()* self.vae.config.scaling_factor
-
         # 5. Prepare timesteps
         self.scheduler.set_timesteps(num_inference_steps, device=device)
         self.scheduler.config.prediction_type = "epsilon"
@@ -955,6 +945,17 @@ class StableDiffusionSIDModelImg2ImgPipeline(
         # 6. Prepare latent variables
         cond_latents = self.vae.encode(image).latent_dist.sample()
         cond_latents = cond_latents * self.vae.config.scaling_factor
+        if use_rough_guidance:
+            rough_label = rough_label.to(device=device)
+            if tuple(rough_label.shape[-2:]) != (height, width):
+                raise ValueError(
+                    f"Rough label tensor shape {tuple(rough_label.shape[-2:])} does not match image size {(height, width)}."
+                )
+            rough_label_embed = self.label_embed_net.encode(rough_label)
+            rough_lbl_latents = self.vae.encode(rough_label_embed).latent_dist.sample()
+            rough_lbl_latents = rough_lbl_latents * self.vae.config.scaling_factor
+        else:
+            rough_lbl_latents = torch.zeros_like(cond_latents)
 
         # num_channels_latents = sidmodel.interact_net.num_classes
         num_channels_latents = 4

--- a/src/models/pipeline_sidmodel_img2img.py
+++ b/src/models/pipeline_sidmodel_img2img.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import inspect
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import PIL.Image
@@ -650,12 +650,16 @@ class StableDiffusionSIDModelImg2ImgPipeline(
         device,
         generator,
         latents=None,
+        latent_shape: Optional[Tuple[int, int]] = None,
     ):
+        latent_height, latent_width = (
+            latent_shape if latent_shape is not None else (height // self.vae_scale_factor, width // self.vae_scale_factor)
+        )
         shape = (
             batch_size,
             num_channels_latents,
-            height // self.vae_scale_factor,
-            width // self.vae_scale_factor,
+            latent_height,
+            latent_width,
         )
         if isinstance(generator, list) and len(generator) != batch_size:
             raise ValueError(
@@ -733,8 +737,8 @@ class StableDiffusionSIDModelImg2ImgPipeline(
         image: PipelineImageInput = None,
         rough_label: PipelineImageInput = None,
         interact_direction: str = "seg",
-        height: Optional[int] = 512,
-        width: Optional[int] = 512,
+        height: Optional[int] = None,
+        width: Optional[int] = None,
         strength: float = 0.8,
         num_inference_steps: int = 50,
         guidance_scale: float = 7.5,
@@ -916,8 +920,23 @@ class StableDiffusionSIDModelImg2ImgPipeline(
         # 4. Prepare image
         dtype = self.text_encoder.dtype
         image = image.to(dtype=dtype).to(device=device)
+        image_height, image_width = image.shape[-2:]
+        height = int(image_height if height is None else height)
+        width = int(image_width if width is None else width)
+        if (height, width) != (image_height, image_width):
+            raise ValueError(
+                f"Image tensor shape {(image_height, image_width)} does not match requested size {(height, width)}."
+            )
+        if height % self.vae_scale_factor != 0 or width % self.vae_scale_factor != 0:
+            raise ValueError(
+                f"Image size {(height, width)} must be divisible by the VAE scale factor {self.vae_scale_factor}."
+            )
         
         rough_label = rough_label.to(device=device)
+        if tuple(rough_label.shape[-2:]) != (height, width):
+            raise ValueError(
+                f"Rough label tensor shape {tuple(rough_label.shape[-2:])} does not match image size {(height, width)}."
+            )
         rough_label_embed = self.label_embed_net.encode(rough_label)
 
         rough_lbl_latents = self.vae.encode(
@@ -948,6 +967,7 @@ class StableDiffusionSIDModelImg2ImgPipeline(
             device,
             generator,
             latents,
+            latent_shape=tuple(cond_latents.shape[-2:]),
         )
 
         # 7. Prepare extra step kwargs. TODO: Logic should ideally just be moved out of the pipeline

--- a/src/utils/align_utils.py
+++ b/src/utils/align_utils.py
@@ -15,6 +15,43 @@ def mean_flat(x):
     return x.mean(dim=list(range(1, x.ndim)))
 
 
+def _ensure_hw_tuple(size):
+    if isinstance(size, int):
+        return (int(size), int(size))
+    if isinstance(size, (tuple, list)) and len(size) == 2:
+        return (int(size[0]), int(size[1]))
+    raise ValueError(f"Expected an int or a 2-value size, got: {size!r}")
+
+
+def _round_down_to_multiple(value: int, multiple: int) -> int:
+    value = int(value)
+    multiple = int(multiple)
+    if value < multiple:
+        raise ValueError(f"Value {value} must be >= multiple {multiple}")
+    return (value // multiple) * multiple
+
+
+def _infer_repa_resize_dim(value: int, patch_size: int) -> int:
+    # Generalize REPA's 512 -> 448 ratio to arbitrary spatial sizes while keeping
+    # the DINO input aligned to the encoder patch size.
+    repa_like_dim = max(patch_size, int(value * 7 / 8))
+    repa_like_dim = min(int(value), repa_like_dim)
+    return _round_down_to_multiple(max(repa_like_dim, patch_size), patch_size)
+
+
+def _resolve_preprocess_size(image_hw, encoder_type=None, patch_size=None):
+    image_h, image_w = _ensure_hw_tuple(image_hw)
+    if encoder_type is None:
+        return (image_h, image_w)
+    if encoder_type == "dinov2":
+        patch_multiple = int(patch_size) if patch_size is not None else 14
+        return (
+            _infer_repa_resize_dim(image_h, patch_multiple),
+            _infer_repa_resize_dim(image_w, patch_multiple),
+        )
+    raise ValueError(f"Unknown encoder type: {encoder_type}")
+
+
 def _resolve_dinov2_code_path():
     local_path = Path(__file__).resolve().parents[1] / "models" / "dinov2"
     if local_path.is_dir():
@@ -58,7 +95,7 @@ def _extract_state_dict(checkpoint):
 @torch.no_grad()
 def load_encoders_from_file(encoder_path, device):
     if encoder_path is None or str(encoder_path) == "None":
-        return None, None, None
+        return None, None, None, None
 
     encoder_path = os.path.abspath(encoder_path)
     if not os.path.exists(encoder_path):
@@ -97,26 +134,28 @@ def load_encoders_from_file(encoder_path, device):
 
     encoder.head = torch.nn.Identity()
     encoder = encoder.to(device).eval()
-    return encoder, encoder_type, architecture
+    return encoder, encoder_type, architecture, patch_size
 
 
 _PREPROCESS_CONFIGS = {
     "dinov2": {
-        "resize": (448, 448),
         "interpolation": InterpolationMode.BICUBIC,
     },
 }
 
 
-def preprocess_image(x, encoder_type=None):
+def preprocess_image(x, encoder_type=None, patch_size=None):
     if encoder_type is None:
         return x
     if encoder_type not in _PREPROCESS_CONFIGS:
         raise ValueError(f"Unknown encoder type: {encoder_type}")
     preprocess_cfg = _PREPROCESS_CONFIGS[encoder_type]
-    if "resize" in preprocess_cfg:
+    target_size = _resolve_preprocess_size(x.shape[-2:], encoder_type=encoder_type, patch_size=patch_size)
+    if tuple(int(dim) for dim in x.shape[-2:]) != target_size:
         resize_transform = transforms.Resize(
-            size=preprocess_cfg["resize"], interpolation=preprocess_cfg["interpolation"]
+            size=target_size,
+            interpolation=preprocess_cfg["interpolation"],
+            antialias=None,
         )
         x = resize_transform(x)
     return x

--- a/src/utils/config_parser.py
+++ b/src/utils/config_parser.py
@@ -3,12 +3,23 @@ import sys
 import yaml
 import argparse
 
+def _resolve_relative_values(value, config_dir):
+    if isinstance(value, dict):
+        return {key: _resolve_relative_values(item, config_dir) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_resolve_relative_values(item, config_dir) for item in value]
+    if isinstance(value, str) and (value.startswith("./") or value.startswith("../")):
+        return os.path.normpath(os.path.join(config_dir, value))
+    return value
+
 
 class ConfigLoader:
     @staticmethod
     def load_recursive(file_path):
+        file_path = os.path.abspath(file_path)
         with open(file_path, 'r') as f:
             cfg = yaml.safe_load(f) or {}
+        cfg = _resolve_relative_values(cfg, os.path.dirname(file_path))
         if '_base_' in cfg:
             base_path = cfg.pop('_base_')
             if not os.path.isabs(base_path):
@@ -18,27 +29,6 @@ class ConfigLoader:
             return base_cfg
         
         return cfg
-
-
-def _resolve_relative_paths(cfg, config_file_path):
-    config_dir = os.path.dirname(os.path.abspath(config_file_path))
-    path_keys = {
-        "pretrained_model_name_or_path",
-        "sd_model_name_or_path",
-        "label_embed_dir",
-        "encoder_path",
-        "train_data_dir",
-        "output_dir",
-        "logging_dir",
-        "cache_dir",
-        "dataset",
-    }
-    resolved = dict(cfg)
-    for key in path_keys:
-        value = resolved.get(key)
-        if isinstance(value, str) and (value.startswith("./") or value.startswith("../")):
-            resolved[key] = os.path.normpath(os.path.join(config_dir, value))
-    return resolved
 
 
 def parse_args(input_args=None):
@@ -51,7 +41,6 @@ def parse_args(input_args=None):
     cfg_defaults = {}
     if pre_args.config_file is not None:
         cfg_defaults = ConfigLoader.load_recursive(pre_args.config_file)
-        cfg_defaults = _resolve_relative_paths(cfg_defaults, pre_args.config_file)
 
     parser = argparse.ArgumentParser(description="IDGBR Training Script (Original Config)")
     parser.add_argument("--config_file", type=str, default=None, help="Path to yaml config file")

--- a/src/utils/infer_config.py
+++ b/src/utils/infer_config.py
@@ -3,27 +3,6 @@ import os
 
 from src.utils.config_parser import ConfigLoader
 
-
-_PATH_KEYS = {
-    "model_path",
-    "base_model_name_or_path",
-    "label_embed_dir",
-    "data_dir",
-    "dataset",
-    "output_dir",
-}
-
-
-def _resolve_relative_paths(cfg, config_file_path):
-    config_dir = os.path.dirname(os.path.abspath(config_file_path))
-    resolved = dict(cfg)
-    for key in _PATH_KEYS:
-        value = resolved.get(key)
-        if isinstance(value, str) and value and not os.path.isabs(value):
-            resolved[key] = os.path.normpath(os.path.join(config_dir, value))
-    return resolved
-
-
 def _normalize_checkpoint(value):
     if value is None:
         return None
@@ -55,7 +34,6 @@ def parse_infer_args(input_args=None):
     cfg_defaults = {}
     if pre_args.config_file:
         cfg_defaults = ConfigLoader.load_recursive(pre_args.config_file)
-        cfg_defaults = _resolve_relative_paths(cfg_defaults, pre_args.config_file)
 
     parser = argparse.ArgumentParser(description="IDGBR inference")
     parser.add_argument("--config_file", type=str, default=None, help="Path to yaml config file")
@@ -76,12 +54,14 @@ def parse_infer_args(input_args=None):
     parser.add_argument("--negative_prompt", type=str, default=None, help="Negative prompt")
     parser.add_argument("--use_dataset_text", dest="use_dataset_text", action="store_true", help="Use text from dataset metadata")
     parser.add_argument("--no_use_dataset_text", dest="use_dataset_text", action="store_false", help="Ignore text from dataset metadata")
+    parser.add_argument("--use_rough_guidance", dest="use_rough_guidance", action="store_true", help="Use rough label guidance")
+    parser.add_argument("--no_use_rough_guidance", dest="use_rough_guidance", action="store_false", help="Disable rough label guidance")
     parser.add_argument("--seed", type=int, default=42, help="Random seed")
     parser.add_argument("--deterministic", action="store_true", help="Enable deterministic inference")
     parser.add_argument("--max_samples", type=int, default=None, help="Optional sample cap for quick runs")
     parser.add_argument("--skip_existing", dest="skip_existing", action="store_true", help="Skip predictions that already exist")
     parser.add_argument("--no_skip_existing", dest="skip_existing", action="store_false", help="Always overwrite predictions")
-    parser.set_defaults(use_dataset_text=True, skip_existing=True, deterministic=True)
+    parser.set_defaults(use_dataset_text=True, use_rough_guidance=True, skip_existing=True, deterministic=True)
 
     if cfg_defaults:
         parser.set_defaults(**cfg_defaults)

--- a/src/utils/label_embed_config.py
+++ b/src/utils/label_embed_config.py
@@ -1,16 +1,7 @@
 import os
 import argparse
 
-from src.utils.config_parser import ConfigLoader, _resolve_relative_paths
-
-
-def _resolve_extra_paths(cfg, config_file_path):
-    config_dir = os.path.dirname(os.path.abspath(config_file_path))
-    for key in ("init_from", "output_dir"):
-        value = cfg.get(key)
-        if isinstance(value, str) and (value.startswith("./") or value.startswith("../")):
-            cfg[key] = os.path.normpath(os.path.join(config_dir, value))
-    return cfg
+from src.utils.config_parser import ConfigLoader
 
 
 def parse_args(input_args=None):
@@ -24,8 +15,6 @@ def parse_args(input_args=None):
     cfg_defaults = {}
     if pre_args.config_file is not None:
         cfg_defaults = ConfigLoader.load_recursive(pre_args.config_file)
-        cfg_defaults = _resolve_relative_paths(cfg_defaults, pre_args.config_file)
-        cfg_defaults = _resolve_extra_paths(cfg_defaults, pre_args.config_file)
 
     parser = argparse.ArgumentParser(description="LabelEmbedNet Training Script")
     parser.add_argument("--config_file", type=str, default=None, help="Path to yaml config file")

--- a/tools/infer.py
+++ b/tools/infer.py
@@ -347,6 +347,7 @@ def main():
                 negative_prompt=args.negative_prompt,
                 image=batch["image"],
                 rough_label=batch["rough_label_index"],
+                use_rough_guidance=args.use_rough_guidance,
                 strength=args.strength,
                 num_inference_steps=args.num_inference_steps,
                 guidance_scale=args.guidance_scale,

--- a/tools/train.py
+++ b/tools/train.py
@@ -117,18 +117,21 @@ def main(args):
 
     noise_scheduler = DDIMScheduler.from_pretrained(args.sd_model_name_or_path, subfolder="scheduler")
     noise_scheduler.config.prediction_type = "epsilon"
+    vae_scale_factor = None
     
     text_encoder = text_encoder_cls.from_pretrained(args.sd_model_name_or_path, subfolder="text_encoder", revision=args.revision,)
     
     vae = AutoencoderKL.from_pretrained(args.sd_model_name_or_path, subfolder="vae", revision=args.revision)
+    vae_scale_factor = 2 ** (len(vae.config.block_out_channels) - 1)
     unet_ori = UNet2DConditionEncodeModel.from_pretrained(args.sd_model_name_or_path, subfolder="unet", revision=args.revision,)
     unet_gen = UNet2DConditionNewModel.from_pretrained(args.sd_model_name_or_path, subfolder="unet", revision=args.revision,)
     interact_net = InteractNet()
     label_embed_net = LabelEmbedNet.from_pretrained(args.label_embed_dir, revision=args.revision,)
     encoder = None
     encoder_type = None
+    encoder_patch_size = None
     if args.enable_alignment:
-        encoder, encoder_type, _ = load_encoders_from_file(args.encoder_path, accelerator.device)
+        encoder, encoder_type, _, encoder_patch_size = load_encoders_from_file(args.encoder_path, accelerator.device)
     z_dims = [encoder.embed_dim] if encoder is not None else None
 
     # --------------------------------------------------------------------------
@@ -363,15 +366,31 @@ def main(args):
     for epoch in range(first_epoch, args.num_train_epochs):
         for step, batch in enumerate(train_dataloader):
             with accelerator.accumulate(sid_model):
+                if batch["image"].shape[-2] % vae_scale_factor != 0 or batch["image"].shape[-1] % vae_scale_factor != 0:
+                    raise ValueError(
+                        f"Dataset resize produced image shape {tuple(batch['image'].shape[-2:])}, "
+                        f"which must be divisible by the VAE scale factor {vae_scale_factor}."
+                    )
                 representators_outputs = None
+                representators_token_grid = None
                 if args.enable_alignment and encoder is not None and global_step < args.acc_steps:
                     with torch.no_grad(), accelerator.autocast():
+                        encoder_inputs = preprocess_image(
+                            batch["image"],
+                            encoder_type=encoder_type,
+                            patch_size=encoder_patch_size,
+                        )
                         representators_output = encoder.forward_features(
-                            preprocess_image(batch["image"], encoder_type=encoder_type)
+                            encoder_inputs
                         )
                         if isinstance(representators_output, dict) and "x_norm_patchtokens" in representators_output:
                             representators_output = representators_output["x_norm_patchtokens"]
                         representators_outputs = [representators_output]
+                        if encoder_patch_size is not None:
+                            representators_token_grid = (
+                                encoder_inputs.shape[-2] // encoder_patch_size,
+                                encoder_inputs.shape[-1] // encoder_patch_size,
+                            )
                 elif args.enable_alignment and encoder is not None and (not alignment_released) and global_step >= args.acc_steps:
                     if accelerator.is_main_process:
                         accelerator.print("Alignment finished. Release DINO encoder from GPU.")
@@ -418,12 +437,14 @@ def main(args):
                     token_captions10 = torch.stack([example for example in tokenize_captions(batch_mask_text10)])
                     encoder_hidden_states10 = text_encoder(token_captions10.to(accelerator.device))[0]
 
-                    model_pred, representators_tilde = sid_model.get_gen_pred(
+                    model_pred, representators_tilde = sid_model(
                         noise_latents=noisy_latents,
                         cond_latents_1=img_latents,
                         cond_latents_2=rough_lbl_latents,
                         timesteps=timesteps,
                         encoder_hidden_states=encoder_hidden_states10,
+                        target_token_grid=representators_token_grid,
+                        return_representations=True,
                     )
 
                 denoising_loss = F.mse_loss((model_pred).float(), (noise).float(), reduction="mean")
@@ -438,11 +459,16 @@ def main(args):
                                 mode="linear",
                                 align_corners=False,
                             ).permute(0, 2, 1)
-                        representator_output = F.normalize(representator_output, dim=-1)
-                        representator_tilde = F.normalize(representator_tilde, dim=-1)
-                        proj_loss = proj_loss + mean_flat(
-                            -(representator_output * representator_tilde).sum(dim=-1)
-                        ).mean()
+                        representator_output = representator_output.float()
+                        representator_tilde = representator_tilde.float()
+                        representator_output = F.normalize(representator_output, dim=-1, eps=1e-6)
+                        tilde_norm = representator_tilde.norm(dim=-1, keepdim=True)
+                        valid_mask = tilde_norm.squeeze(-1) > 1e-6
+
+                        if valid_mask.any():
+                            representator_tilde = representator_tilde / tilde_norm.clamp_min(1e-6)
+                            cosine_per_token = -(representator_output * representator_tilde).sum(dim=-1)
+                            proj_loss = proj_loss + cosine_per_token[valid_mask].mean()
                     proj_loss = proj_loss / len(representators_outputs)
                     total_loss = denoising_loss + proj_loss * args.proj_coeff
                 else:


### PR DESCRIPTION
Two commits on top of `main` (07927a9):

## 3d88458 — Stabilize V0.2.1 alignment and resolution handling
- `evaluation/boundary.py`: stop deleting the shared `label_edge_dir` cache after each job so repeat evals reuse label edges.
- `src/models/SuperModel.py`: add `@register_to_config` to `InteractNet`, drop the hard-coded `spatial_expander` MLP, and replace it with bilinear interpolation of projector output to a runtime `target_token_grid` so alignment works at any spatial size.
- `src/models/clip.py`: `CrossAttentionLayer` now accepts non-square `patch_size` / `input_resolution` and interpolates its positional embedding to the observed grid.
- `src/models/pipeline_sidmodel_img2img.py`: infer `(height, width)` from the input image when unset, validate divisibility by `vae_scale_factor`, and pass the true latent shape into `prepare_latents`.
- `src/utils/align_utils.py`: return `patch_size` from `load_encoders_from_file`; generalize DINOv2 preprocessing to round down to the patch multiple at 7/8 of the input side (REPA-style 512→448 ratio) instead of hard-coding 448.
- `tools/train.py`: wire `encoder_patch_size` / `representators_token_grid` through training, validate dataset shape vs VAE scale, and make the alignment loss use a per-token validity mask so zero-normed tildes don't NaN the mean.

## 87f7b92 — Resolve config paths recursively and support optional rough guidance
- `src/utils/config_parser.py`: move relative-path resolution into `ConfigLoader.load_recursive` so every `./`/`../` value is resolved against the file that declares it — fixes base-config paths loaded through `_base_`.
- `src/utils/infer_config.py`, `src/utils/label_embed_config.py`: drop the now-redundant per-parser path resolution helpers.
- `src/models/pipeline_sidmodel_img2img.py` + `tools/infer.py` + `configs/inference/{CHN6-CUG,Potsdam}/no_rough.yaml`: add `use_rough_guidance` flag. When `False` the pipeline swaps the rough-label latents for zeros, so the no_rough experiments drop rough-label conditioning cleanly.

## Validation
Potsdam `no_rough_001` inference finished 2026-04-21 21:05 (2016 tiles). Re-ran eval today on 2026-04-22:
- mIoU 0.7057, Mean F1 0.8260, WF(3px) 0.3557 — bit-identical to yesterday's run (2026-04-21 21:07), confirming the re-running eval and deterministic path. See `evaluation_results/Potsdam/no_rough_001.txt`.
